### PR TITLE
hotfix: Remove comma from Routes object

### DIFF
--- a/app/src/app/app-routing.module.ts
+++ b/app/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 
 const routes: Routes = [
-    { path: '**', component: HomeComponent },
+    { path: '**', component: HomeComponent }
 ];
 
 @NgModule({


### PR DESCRIPTION
## What?

Remove comma from Routes object

## Why?

It prevents the app from running, it crashes.

## Anything else?

The application should have a Continuous Integration schema/workflow to prevent this type of incidents

